### PR TITLE
Fix SBICrypto strings to match pattern

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -8,11 +8,11 @@
             "name": "Multipool.us",
             "link": "https://www.multipool.us/dashboard/pool/bch"
         },
-        "/SBI Crypto/": {
+        "SBI Crypto": {
             "name": "SBI Crypto",
             "link": "https://sbicrypto.com"
         },
-        "/SBICrypto/": {
+        "SBICrypto": {
             "name": "SBI Crypto",
             "link": "https://sbicrypto.com"
         },


### PR DESCRIPTION
example
https://bch.btc.com/622e44e4851dc9508f81c5ea0218153551aff1e7e15e30836264363843a1d876

"/SBICrypto.com Pool/BCHN/"

Currently matching is broken